### PR TITLE
Fix ESlint config

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -16,6 +16,6 @@ module.exports = {
       'warn',
       { allowConstantExport: true },
     ],
-    'no-unused-vars': false
+    'no-unused-vars': 0
   },
 }


### PR DESCRIPTION
When you run ESlint the following error is throwing:
![image](https://github.com/fullstack-hy2020/query-anecdotes/assets/49842769/252310b6-4d4f-4d1c-8c97-7daaf20f82a9)
Fixed by changing rule `no-unused-vars` from `false` to `0`.